### PR TITLE
shadow() deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nim-version: ['1.6.20', '2.0.4', 'stable']
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Nim
+      uses: jiro4989/setup-nim-action@v2
+      with:
+        nim-version: ${{ matrix.nim-version }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Run example
+      run: nim c -r example.nim

--- a/lapper.nimble
+++ b/lapper.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.7"
+version       = "0.1.8"
 author        = "Brent Pedersen"
 description   = "fast, simple interval overlaps with binary search"
 license       = "MIT"

--- a/src/lapper.nim
+++ b/src/lapper.nim
@@ -129,7 +129,6 @@ proc empty*[T:Interval](L:Lapper[T]): bool {.inline.} =
 iterator find*[T:Interval](L:var Lapper[T], start:int, stop:int): T =
   ## fill ivs with all intervals in L that overlap start .. stop.
   #if ivs.len != 0: ivs.set_len(0)
-  shallow(L.intervals)
   let off = lowerBound(L.intervals, start - L.max_len)
   for i in off..L.intervals.high:
     let x = L.intervals[i]
@@ -140,7 +139,6 @@ iterator find*[T:Interval](L:var Lapper[T], start:int, stop:int): T =
 proc find*[T:Interval](L:var Lapper[T], start:int, stop:int, ivs:var seq[T]): bool =
   ## fill ivs with all intervals in L that overlap start .. stop.
   #if ivs.len != 0: ivs.set_len(0)
-  shallow(L.intervals)
   let off = lowerBound(L.intervals, start - L.max_len)
   var n = 0
   for i in off..L.intervals.high:
@@ -158,7 +156,6 @@ proc find*[T:Interval](L:var Lapper[T], start:int, stop:int, ivs:var seq[T]): bo
 
 proc count*[T:Interval](L:var Lapper[T], start:int, stop:int): int =
   ## fill ivs with all intervals in L that overlap start .. stop.
-  shallow(L.intervals)
   let off = lowerBound(L.intervals, start - L.max_len)
   for i in off..L.intervals.high:
     let x = L.intervals[i]


### PR DESCRIPTION
Hi Brent,
I noticed I can no longer compile lapper with Nim 2:

```
        ... /home/telatina/.nimble/pkgs2/lapper-0.1.7-d6b2a932f7b8f786a40c452e763a837603c119ea/lapper.nim(132, 10) Error: undeclared identifier: 'shallow'
nimble.nim(415)          buildFromDir
```

removing shallow() makes the code compatible with Nim 2.x (I tested with Nim 2.0.4, 2.2.4 and 1.6.20).

Let me know if you think this makes sense or if you have suggestions; I added a minimal Github action testing against the three versions mentioned, but just running `nim c -r example.nim`, as `nimble test` is quite long to run.

Cheers!